### PR TITLE
Active Reservations: make info text selectable

### DIFF
--- a/app/src/main/res/layout/item_row_active_reservation.xml
+++ b/app/src/main/res/layout/item_row_active_reservation.xml
@@ -134,6 +134,7 @@
 
                 <TextView
                     android:id="@+id/reservationInfo"
+                    android:textIsSelectable="true"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:textColor="?attr/primaryTextColor" />


### PR DESCRIPTION
As the title suggests, this PR makes a small change: it makes the reservation info text selectable, which may be useful in certain situations.

@matypist This was part of a (major) work done to improve the original app, and if I have time I will cherrypick some of those contributions.