### PR TITLE
fix: fix wrong date for google calendar event

### DIFF
--- a/app/src/main/java/net/sapienzastudents/matypist/openstud/helpers/ClientHelper.java
+++ b/app/src/main/java/net/sapienzastudents/matypist/openstud/helpers/ClientHelper.java
@@ -247,9 +247,11 @@ public class ClientHelper {
         if (Locale.getDefault().getLanguage().equals("it"))
             title = "Esame: " + res.getExamSubject();
         else title = "Exam: " + res.getExamSubject();
-        intent.putExtra(CalendarContract.Events.TITLE, title);
-        intent.putExtra(CalendarContract.EXTRA_EVENT_BEGIN_TIME,
-                (timestamp.getTime() + 1000) * 1000L);
+        long startTime = timestamp.getTime() * 1000L; // Convert to milliseconds
+        long endTime = startTime + (24 * 60 * 60 * 1000L); // One day later in milliseconds
+
+        intent.putExtra(CalendarContract.EXTRA_EVENT_BEGIN_TIME, startTime);
+        intent.putExtra(CalendarContract.EXTRA_EVENT_END_TIME, endTime);
         intent.putExtra(CalendarContract.Events.ALL_DAY, true);
         activity.startActivity(intent);
     }

--- a/app/src/main/java/net/sapienzastudents/matypist/openstud/helpers/ClientHelper.java
+++ b/app/src/main/java/net/sapienzastudents/matypist/openstud/helpers/ClientHelper.java
@@ -249,7 +249,7 @@ public class ClientHelper {
         else title = "Exam: " + res.getExamSubject();
         intent.putExtra(CalendarContract.Events.TITLE, title);
         intent.putExtra(CalendarContract.EXTRA_EVENT_BEGIN_TIME,
-                timestamp.getTime() * 1000L);
+                (timestamp.getTime() + 1000) * 1000L);
         intent.putExtra(CalendarContract.Events.ALL_DAY, true);
         activity.startActivity(intent);
     }


### PR DESCRIPTION
this PR fixes an issue with google calendar for Android 12+ that set the event a day before the expected day.

### Screenshots of the issue:

![image](https://github.com/user-attachments/assets/f1847e25-7b0b-4055-a6c3-a07379c52f28)  
![image](https://github.com/user-attachments/assets/85ea33d0-7b49-45a4-9757-79a03b27268c)

### Probable Explanation
All-day events in Google Calendar are treated differently from timed events. For all-day events, the start time should be at midnight (00:00:00) in UTC to match the intended date. When you set an all-day event, the calendar interprets the timestamp as midnight in UTC.

#### Timestamp Issues
For istance, the timestamp `1736208000000` corresponds to midnight on **January 7, 2025, in UTC.** However, when you set an all-day event, Google Calendar might interpret this timestamp as the end of the previous day due to how it handles the day transition:
